### PR TITLE
add_edge! returns (ok, new_edge)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## v0.x.y
+- `add_edge!` now returns `(ok, new_edge)` instead of just `ok`
 
 ## v0.1.3  2017.3.8
 - doc system updates

--- a/src/core/interface.jl
+++ b/src/core/interface.jl
@@ -38,16 +38,17 @@ Time Complexity: O(1)
 ne(g::ASimpleGraph) = error("Method not defined")
 
 """
-    add_edge!(g, e)
+    add_edge!(g, e) -> (ok, new_edge)
 
 Add to `g` the edge `e`.
 
-    add_edge!(g, u, v)
+    add_edge!(g, u, v) -> (ok, new_edge)
 
 Add to `g` an edge from `u` to `v`.
 
-Will return false if add fails (e.g., if vertices are not in the graph or the edge
-is already present) and true otherwise.
+`ok=false` if add fails (e.g. if vertices are not in the graph or the edge
+is already present) and `true` otherwise.
+`new_edge` is the descriptor of the new edge.
 """
 add_edge!(g::ASimpleGraph, u, v) = error("Method not defined")
 

--- a/src/factory/gtgraph.jl
+++ b/src/factory/gtgraph.jl
@@ -141,8 +141,8 @@ function add_vertex!(g::GTDiGraph)
 end
 
 function add_edge!(g::GTDiGraph, u::Integer, v::Integer)
-    (u in vertices(g) && v in vertices(g)) || return false
-    has_edge(g, u, v) && return false # could be removed for multigraphs
+    (u in vertices(g) && v in vertices(g)) || return (false, GTEdge(u,v,-1))
+    has_edge(g, u, v) && return (false, GTEdge(u,v,-1)) # could be removed for multigraphs
     if isempty(g.free_indexes)
         g.edge_index_range += 1
         idx = g.edge_index_range
@@ -160,7 +160,7 @@ function add_edge!(g::GTDiGraph, u::Integer, v::Integer)
         g.epos[idx] = Pair(length(oes), length(ies))
     end
 
-    return true
+    return (true, GTEdge(u,v,idx))
 end
 
 function rem_edge!(g::GTDiGraph, s::Integer, t::Integer)
@@ -302,8 +302,9 @@ function add_vertex!(g::GTGraph)
 end
 
 function add_edge!(g::GTGraph, u::Integer, v::Integer)
-    (u in vertices(g) && v in vertices(g)) || return false
-    has_edge(g, u, v) && return false # could be removed for multigraphs
+    u, v = u <= v ? (u, v) : (v, u)
+    (u in vertices(g) && v in vertices(g)) || return (false, GTEdge(u,v,-1))
+    has_edge(g, u, v) && return (false, GTEdge(u,v,-1)) # could be removed for multigraphs
 
     if u > v
         u,v = v,u
@@ -327,7 +328,7 @@ function add_edge!(g::GTGraph, u::Integer, v::Integer)
         g.epos[idx] = Pair(length(oes), length(ies))
     end
 
-    return true
+    return (true, GTEdge(u,v,idx))
 end
 
 function rem_edge!(g::GTGraph, s::Integer, t::Integer)

--- a/src/generators/randgraphs.jl
+++ b/src/generators/randgraphs.jl
@@ -71,7 +71,7 @@ function watts_strogatz{G<:ASimpleGraph}(n::Int, k::Int, β::Real, ::Type{G} = G
                         end
                     end
                     if s != d
-                        add_edge!(g, s, d) && break
+                        add_edge!(g, s, d)[1] && break
                     end
                 end
             end
@@ -305,7 +305,7 @@ function _create_static_fitness_graph!{T<:Real,S<:Real}(g::ASimpleGraph, m::Int,
         (source == target) && continue
         edge = Edge(source, target)
         # is there already an edge? If so, try again
-        add_edge!(g, edge) || continue
+        add_edge!(g, edge)[1] || continue
         m -= 1
     end
 end
@@ -530,7 +530,7 @@ function stochastic_block_model{T<:Real, G<:AGraph}(c::Matrix{T}, n::Vector{Int}
                 source = rand(rng, ra)
                 dest = rand(rng, rb)
                 if source != dest
-                    if add_edge!(g, source, dest)
+                    if add_edge!(g, source, dest)[1]
                         i += 1
                     end
                 end

--- a/test/core/core.jl
+++ b/test/core/core.jl
@@ -33,11 +33,10 @@ e4 = E(2,5)
 e5 = E(3,5)
 
 g = G(5)
-@test add_edge!(g, 1, 2)
-@test add_edge!(g, e2)
-@test add_edge!(g, e3)
-@test add_edge!(g, e4)
-@test add_edge!(g, e5)
+@test add_edge!(g, 1, 2) == (true, edge(g, 1, 2))
+for e in [e2,e3,e4,e5]
+    @test add_edge!(g, e) == (true, edge(g, src(e), dst(e)))
+end
 
 g6 = G(5)
 unsafe_add_edge!(g6, 1, 2)
@@ -50,11 +49,10 @@ rebuild!(g6)
 @test g6 == g
 
 h = DG(5)
-@test add_edge!(h, 1, 2)
-@test add_edge!(h, e2)
-@test add_edge!(h, e3)
-@test add_edge!(h, e4)
-@test add_edge!(h, e5)
+@test add_edge!(h, 1, 2) == (true, edge(h, 1, 2))
+for e in [e2,e3,e4,e5]
+    @test add_edge!(h, e) == (true, edge(h, src(e), dst(e)))
+end
 
 @test vertices(g) == 1:5
 i = 0
@@ -100,10 +98,10 @@ end
 
 @test collect(neighbors(g, 1)) == [2, 3, 4]
 
-@test add_edge!(g, 1, 1)
+@test add_edge!(g, 1, 1) == (true, edge(g, 1, 1))
 @test has_self_loops(g)
 @test num_self_loops(g) == 1
-@test !add_edge!(g, 1, 1)
+@test add_edge!(g, 1, 1) == (false, edge(g, 1, 1))
 @test rem_edge!(g, 1, 1)
 @test !rem_edge!(g, 1, 1)
 
@@ -119,7 +117,7 @@ add_edge!(g, 1, 2)
 @test has_edge(g,2,1)
 @test has_edge(g,1,2)
 @test rem_edge!(g, 2, 1)
-@test add_edge!(h, 1, 1)
+@test add_edge!(h, 1, 1) == (true, edge(g, 1, 1))
 @test rem_edge!(h, 1, 1)
 @test rem_edge!(h, 1, 2)
 @test !rem_edge!(h, 1, 2)
@@ -227,7 +225,7 @@ g10 = PathGraph(3, G)
 g10 = PathGraph(4, G)
 @test rem_vertex!(g10, 3)
 h10 =G(3)
-@test add_edge!(h10,1,2)
+@test add_edge!(h10,1,2) == (true, edge(h10, 1, 2))
 @test g10 == h10
 
 g10 = CompleteGraph(5, G)
@@ -246,17 +244,16 @@ g3 = PathGraph(5, G)
 @test density(g3) == 0.4
 
 g = G(5)
-@test add_edge!(g, 1, 2)
+@test add_edge!(g, 1, 2) == (true, edge(g, 1, 2))
 
 e2 = E(1,3)
 e3 = E(1,4)
 e4 = E(2,5)
 e5 = E(3,5)
 
-@test add_edge!(g, e2)
-@test add_edge!(g, e3)
-@test add_edge!(g, e4)
-@test add_edge!(g, e5)
+for e in [e2,e3,e4,e5]
+    @test add_edge!(g, e) == (true, edge(g, src(e), dst(e)))
+end
 
 for i in out_neighbors(g, 1)
     @test typeof(i) == V
@@ -272,11 +269,10 @@ for i in out_neighbors(h, 1)
 end
 
 h = DG(5)
-@test add_edge!(h, 1, 2)
-@test add_edge!(h, e2)
-@test add_edge!(h, e3)
-@test add_edge!(h, e4)
-@test add_edge!(h, e5)
+@test add_edge!(h, 1, 2) == (true, edge(h, 1, 2))
+for e in [e2,e3,e4,e5]
+    @test add_edge!(h, e) == (true, edge(h, src(e), dst(e)))
+end
 
 @test collect(out_edges(h, 3)) == collect(edges(h, 3))
 @test length(collect(out_edges(h, 3))) == 1
@@ -323,9 +319,8 @@ badadjmx = [ 0 1 0; 1 0 1]
 @test_throws ErrorException DG(badadjmx)
 @test_throws ErrorException DG(sparse(badadjmx))
 
-
-@test !add_edge!(g, 100, 100)
-@test !add_edge!(h, 100, 100)
+@test add_edge!(g, 100, 100) == (false, edge(g, 100, 100))
+@test add_edge!(h, 100, 100) == (false, edge(h, 100, 100))
 
 g = G(sparse(adjmx1))
 h = DG(sparse(adjmx1))


### PR DESCRIPTION
Since it can be convenient to have the newly created edge for immediate use. Also this is the standard for most graph libraryies. In the future it should be reconsidered if just error in case of insertion failure instead of returning `ok=false` 