### PR TITLE
seed explicitly MersenneTwister(0)

### DIFF
--- a/src/generators/randgraphs.jl
+++ b/src/generators/randgraphs.jl
@@ -509,7 +509,7 @@ function stochastic_block_model{T<:Real, G<:AGraph}(c::Matrix{T}, n::Vector{Int}
     @assert size(c,2) == length(n)
     # init dsfmt generator without altering GLOBAL_RNG
     seed > 0 && Base.dSFMT.dsfmt_gv_init_by_array(MersenneTwister(seed).seed+1)
-    rng =  seed > 0 ? MersenneTwister(seed) : MersenneTwister()
+    rng =  MersenneTwister(max(0, seed))
 
     N = sum(n)
     K = length(n)


### PR DESCRIPTION
The default constructor `MersenneTwister()` will be deprecated, cf. https://github.com/JuliaLang/julia/pull/16984#issuecomment-290914407.