### PR TITLE
add contract!, improve rem_vertices!

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,13 @@
-## v0.5  2017.6.x
+## v0.5  2017.7.10
+- add constructors `EdgeMap(g, e -> f(e))` and `VertexMap(g, v->f(v))`
 - add `sort` for edges
 - add `size(emap)` for edge map `emap` returning `(nv(g), nv(g))`
 - add `Vector(vmap)`  
-- fix bug in `has_edge`
+- fix bug in `has_edge` throwing error in some corner cases
 - add `contract!` method
 - add `rem_vertices!(g, v1, v2, ....)`
-
+- `rem_vertices!` now returns a vertex map of the reindexed vertices instead of a vector of length `nv(g)`
+- fix docs deploy
 
 ## v0.4  2017.6.16
 - faster constructor from matrix. Also add the possibility to select only the upper triangular and/or the non-diagonal part.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 - add `sort` for edges
 - add `size(emap)` for edge map `emap` returning `(nv(g), nv(g))`
 - add `Vector(vmap)`  
+- fix bug in `has_edge`
+- add `contract!` method
+- add `rem_vertices!(g, v1, v2, ....)`
 
 
 ## v0.4  2017.6.16

--- a/docs/src/indexbase.md
+++ b/docs/src/indexbase.md
@@ -1,13 +1,16 @@
 # Erdos
-Erdos is a graph library written in Julia. Installation is straightforward:
+**Erdos** is a graph library written in Julia. Installation is straightforward:
 ```julia
 julia> Pkg.add("Erdos")
 ```
-Erdos defines two abstract type, `AGraph` and `ADiGraph`, from which all
-concrete undirected and directed graph types are derived.
+Erdos defines two abstract graph types, `AGraph` and `ADiGraph`, from which all concrete undirected and directed graph types are derived.
 
-All graphs  in Erdos have `1:n` indexed vertices, where `n` is the number of vertices.
-Multi-edges are not allowed. Self-edges are experimentally supported. Provided this constraints, new graph types can be easily introduced, just defining a few basic methods.
+Two concrete graph types, `Graph` and `Network`, and two digraph types, `DiGraph` and `DiNetwork` are implemented. In all these types the graph topology is represented internally as an adjacency list for each vertex. `(Di)Network`s come with some additional features over `(Di)Graph`s:
+
+ - each edge has a unique index;
+ - vertex/edge maps (also called properties) can be stored internally.
+
+All graphs in **Erdos** have `1:n` indexed vertices, where `n` is the number of vertices. Multi-edges are not allowed. Self-edges are experimentally supported. Provided this constraints, new graph types can be easily introduced just defining a few basic methods.
 
 ## Basic examples
 ### Constructors
@@ -17,6 +20,9 @@ julia> using Erdos
 
 julia> g = CompleteGraph(100)
 Graph{Int64}(100, 4950)
+
+julia> g = Network(10, 30) # a random graph with 10 vertex and 30 edges
+Network(10, 30)
 
 julia> g = Graph{Int32}(100)
 Graph{Int32}(100, 0)

--- a/src/Erdos.jl
+++ b/src/Erdos.jl
@@ -69,7 +69,7 @@ complement, blkdiag, union, intersect,
 difference, symmetric_difference,
 join, tensor_product, cartesian_product, crosspath,
 subgraph, egonet, complete, complete!,
-subnetwork,
+subnetwork, contract!,
 
 # graph visit
 SimpleGraphVisitor, TrivialGraphVisitor, LogGraphVisitor,

--- a/src/Erdos.jl
+++ b/src/Erdos.jl
@@ -108,7 +108,6 @@ cores, kcore,
 adjacency_matrix,laplacian_matrix,
 CombinatorialAdjacency, nonbacktracking_matrix, incidence_matrix,
 nonbacktrack_embedding, Nonbacktracking,
-contract,
 
 # astar
 a_star,

--- a/src/centrality/kcore.jl
+++ b/src/centrality/kcore.jl
@@ -62,8 +62,8 @@ end
 """
     kcore(g, k) -> (gnew, vmap)
 
-Returns the `k`-core  of `g` along with and vector that associates the new vertices
-to the old ones.
+Returns the `k`-core  of `g` along with a vertex map associating the mutated vertex
+indexes to the old ones (as in [`rem_vertices!`](@ref)).
 
 See also [`cores`](@ref)
 """

--- a/src/centrality/kcore.jl
+++ b/src/centrality/kcore.jl
@@ -68,7 +68,8 @@ to the old ones.
 See also [`cores`](@ref)
 """
 function kcore(g::AGraph, k::Integer)
+    #TODO use subgraph
     gnew = copy(g)
-    vmap = rem_vertices!(gnew, find(d-> d<k, cores(g)))
+    vmap = rem_vertices!(gnew, find(d -> d < k, cores(g)))
     return gnew, vmap
 end

--- a/src/community/detection.jl
+++ b/src/community/detection.jl
@@ -1,18 +1,19 @@
 """
-    community_detection_nback(g::AGraph, k::Int)
+    community_detection_nback(g, k)
 
 Community detection using the spectral properties of
-the non-backtracking matrix of `g` (see [Krzakala et al.](http://www.pnas.org/content/110/52/20935.short)).
+the non-backtracking matrix of graph `g` (see [Krzakala et al.](http://www.pnas.org/content/110/52/20935.short)).
+`k` is the number of communities to detect.
 
-`g`: imput Graph
-`k`: number of communities to detect
+See also [`community_detection_bethe`](@ref) for a related community ddetection
+algorithm.
 
-return : array containing vertex assignments
+Returns a vector with the vertex assignments in the communities.
 """
-function community_detection_nback(g::AGraph, k::Int)
+function community_detection_nback(g::AGraph, k::Integer)
     #TODO insert check on connected_components
     ϕ = real(nonbacktrack_embedding(g, k))
-    if k==2
+    if k == 2
         c = community_detection_threshold(g, ϕ[1,:])
     else
         c = kmeans(ϕ, k).assignments
@@ -31,18 +32,19 @@ function community_detection_threshold(g::AGraphOrDiGraph, coords::AbstractArray
     return c
 end
 
+"""
+    nonbacktrack_embedding(g::AGraph, k::Int)
 
-""" Spectral embedding of the non-backtracking matrix of `g`
+Spectral embedding of the non-backtracking matrix of `g`
 (see [Krzakala et al.](http://www.pnas.org/content/110/52/20935.short)).
 
-`g`: imput Graph
-`k`: number of dimensions in which to embed
+    `g`: imput Graph
+    `k`: number of dimensions in which to embed
 
-return : a matrix ϕ where ϕ[:,i] are the coordinates for vertex i.
+Returns  a matrix `ϕ` where `ϕ[:,i]` are the coordinates for vertex `i`.
 
-Note does not explicitly construct the `nonbacktracking_matrix`.
-See `Nonbacktracking` for details.
-
+Note:  does not explicitly construct the [`nonbacktracking_matrix`](@ref).
+See [`Nonbacktracking`](@ref) for details.
 """
 function nonbacktrack_embedding(g::AGraph, k::Int)
     B = Nonbacktracking(g)
@@ -53,8 +55,8 @@ function nonbacktrack_embedding(g::AGraph, k::Int)
     # we might also use the degree distribution to scale these vectors as is
     # common with the laplacian/adjacency methods.
     for n=1:k-1
-        v= eigv[:,n+1]
-        ϕ[:,n] = contract(B, v)
+        v = eigv[:,n+1]
+        ϕ[:,n] = contraction(B, v)
     end
     return ϕ'
 end
@@ -66,7 +68,7 @@ end
 
 Community detection using the spectral properties of
 the Bethe Hessian matrix associated to `g` (see [Saade et al.](http://papers.nips.cc/paper/5520-spectral-clustering-of-graphs-with-the-bethe-hessian)).
-`k` is the number of community to detect. If omitted or if `k<1` the
+`k` is the number of communities to detect. If omitted or if `k < 1` the
 optimal number of communities will be automatically selected.
 In this case the maximum number of detectable communities is given by `kmax`.
 Returns a vector containing the vertex assignments.
@@ -90,10 +92,11 @@ function community_detection_bethe(g::AGraph, k::Int=-1; kmax::Int=15)
 end
 
 """
+    label_propagation(g; maxiter=1000)
+
 Community detection using the label propagation algorithm (see [Raghavan et al.](http://arxiv.org/abs/0709.2938)).
-`g`: input Graph
-`maxiter`: maximum number of iterations
-return : vertex assignments and the convergence history
+`g` is the input Graph, `maxiter` is the  maximum number of iterations.
+Returns a vertex assignments and the convergence history
 """
 function label_propagation(g::AGraphOrDiGraph; maxiter=1000)
     n = nv(g)

--- a/src/core/core.jl
+++ b/src/core/core.jl
@@ -296,7 +296,7 @@ out_adjlist(g::AGraphOrDiGraph) = Vector{Int}[collect(out_neighbors(g, i)) for i
 Returns true if the graph `g` has an edge `e` (from `u` to `v`).
 """
 function has_edge(g::AGraph, u, v)
-    u > nv(g) || v > nv(g) && return false
+    (u > nv(g) || v > nv(g)) && return false
     if degree(g, u) > degree(g, v)
         u, v = v, u
     end

--- a/src/core/core.jl
+++ b/src/core/core.jl
@@ -406,7 +406,7 @@ rebuild!(g::AGraphOrDiGraph) = nothing
 Remove the vertex `v` from graph `g`.
 It will change the label of the last vertex of the old graph to `v`.
 
-See also [`rem_vertices!`](@ref)
+See also [`rem_vertices!`](@ref).
 """
 function rem_vertex!(g::AGraphOrDiGraph, v)
     v in vertices(g) || return false
@@ -422,7 +422,9 @@ end
     rem_vertices!(g, v1, v2, ....)
 
 Remove the vertices in `vs` from graph `g`.
-Returns a vector mapping the vertices in the new graph to the old ones.
+
+Some vertices of `g` may be reindexed during the removal. To keep track of the reindexing,
+a vertex map is returned, associating vertices with changed indexes to their old indexes.
 """
 rem_vertices!(g, vs::Set) = _rem_vertices!(g, sort!(collect(vs)))
 rem_vertices!(g, vs) = _rem_vertices!(g, sort!(union(vs)))
@@ -432,15 +434,14 @@ rem_vertices!(g, vs::Integer...) = _rem_vertices!(g, sort!(union(vs)))
 function _rem_vertices!(g::AGraphOrDiGraph, vlist::Vector)
     n = nv(g)
     nrem = length(vlist)
-    vmap = [1:n-nrem;]
+    # TODO use default vertex map when available
+    vmap = VertexMap(g, vertextype(g))
     vswap = n-nrem+1
     for v in vlist
-        @assert 1 <= v <= n
         if v <= n-nrem
             while vswap in vlist
                 vswap += 1
             end
-            @assert vswap <= n
             clean_vertex!(g, v)
             vmap[v] = vswap
             vswap += 1

--- a/src/core/core.jl
+++ b/src/core/core.jl
@@ -418,14 +418,18 @@ end
 
 
 """
-    rem_vertex!(g, vs)
+    rem_vertices!(g, vs)
+    rem_vertices!(g, v1, v2, ....)
 
 Remove the vertices in `vs` from graph `g`.
-Returns a vector mapping the vertices in the new graph to the
-old ones.
+Returns a vector mapping the vertices in the new graph to the old ones.
 """
-function rem_vertices!(g::AGraphOrDiGraph, vs)
-    vlist = sort(union(vs))
+rem_vertices!(g, vs::Set) = _rem_vertices!(g, sort!(collect(vs)))
+rem_vertices!(g, vs) = _rem_vertices!(g, sort!(union(vs)))
+rem_vertices!(g, vs::Integer...) = _rem_vertices!(g, sort!(union(vs)))
+
+# assume `vlist` sorted and not containing duplicates
+function _rem_vertices!(g::AGraphOrDiGraph, vlist::Vector)
     n = nv(g)
     nrem = length(vlist)
     vmap = [1:n-nrem;]
@@ -443,7 +447,7 @@ function rem_vertices!(g::AGraphOrDiGraph, vs)
         end
     end
 
-    for v in vs
+    for v in vlist
         if v <= n-nrem
             swap_vertices!(g, v, vmap[v])
         end

--- a/src/core/edge.jl
+++ b/src/core/edge.jl
@@ -32,14 +32,7 @@ start(e::AEdge) = 1
 done(e::AEdge, i) = i>2
 next(e::AEdge, i) = (getfield(e,i), i+1)
 # indexed_next(e::Edge, i::Int, state) = (getfield(e,i), i+1)
-
-"""
-    reverse(e::Edge)
-
-Swap `e.src` and `e.dst`.
-"""
 reverse(e::Edge) = Edge(dst(e), src(e))
-
 
 show(io::IO, e::AIndexedEdge) = print(io, "($(src(e))=>$(dst(e)),$(idx(e)))")
 
@@ -68,6 +61,5 @@ src(e::IndexedEdge) = e.src
 dst(e::IndexedEdge) = e.dst
 idx(e::IndexedEdge) = e.idx
 reverse(e::IndexedEdge) = IndexedEdge(e.dst, e.src, e.idx)
-
 
 Base.sort(e::AEdge) = src(e) <= dst(e) ? e : reverse(e)

--- a/src/dismantling/ci.jl
+++ b/src/dismantling/ci.jl
@@ -9,7 +9,7 @@ if the maximum CI goes to zero.
 Set `verbose` to `true` for info printing in each iteration.
 
 Returns `(gnew, vmap, remlist)`, where `gnew` is the reduced graph, `vmap`
-is a vector mapping the vertices of `g` to the old ones (see also [`rem_vertices!`](@ref))
+is a vertex map of the vertices of `gnew` to the old ones (see also [`rem_vertices!`](@ref))
 and `remlist` contains the removed vertices by removal order.
 
 For more fine grained control see [`dismantle_ci_init`](@ref) and

--- a/src/factory/graph.jl
+++ b/src/factory/graph.jl
@@ -192,7 +192,7 @@ in_adjlist(g::DiGraph) = g.badjlist
                 ne(g) == ne(h) && g.fadjlist == h.fadjlist
 
 function has_edge(g::Graph, u, v)
-    u > nv(g) || v > nv(g) && return false
+    (u > nv(g) || v > nv(g)) && return false
     if degree(g, u) > degree(g, v)
         u, v = v, u
     end
@@ -200,7 +200,7 @@ function has_edge(g::Graph, u, v)
 end
 
 function has_edge(g::DiGraph, u, v)
-    u > nv(g) || v > nv(g) && return false
+    (u > nv(g) || v > nv(g)) && return false
     if out_degree(g,u) < in_degree(g,v)
         return length(searchsorted(out_neighbors(g,u), v)) > 0
     else

--- a/src/linalg/nonbacktracking.jl
+++ b/src/linalg/nonbacktracking.jl
@@ -1,10 +1,12 @@
 """
-Given two oriented edges i->j and k->l in g, the
-non-backtraking matrix B is defined as
+    nonbacktracking_matrix(g)
 
-B[i->j, k->l] = δ(j,k)* (1 - δ(i,l))
+Given two oriented edges `i->j` and `k->l` in `g`, the
+non-backtraking matrix `B` is defined as
 
-returns a matrix B, and an edgemap storing the oriented edges' positions in B
+    B[i->j, k->l] = δ(j,k)* (1 - δ(i,l))
+
+Returns a matrix `B`, and an edgemap storing the oriented edges' positions in `B`.
 """
 function nonbacktracking_matrix(g::AGraphOrDiGraph)
     E = Edge{vertextype(g)}
@@ -37,25 +39,32 @@ function nonbacktracking_matrix(g::AGraphOrDiGraph)
     return B, edgeidmap
 end
 
-"""Nonbacktracking: a compact representation of the nonbacktracking operator
+"""
+    type Nonbacktracking{G, E}
+        g::G
+        edgeidmap::Dict{E,Int}
+        m::Int
+    end
+
+A compact representation of the nonbacktracking operator
 
     g: the underlying graph
     edgeidmap: the association between oriented edges and index into the NBT matrix
 
 The Nonbacktracking operator can be used for community detection.
 This representation is compact in that it uses only ne(g) additional storage
-and provides an implicit representation of the matrix B_g defined below.
+and provides an implicit representation of the matrix `B_g` defined below.
 
-Given two oriented edges i->j and k->l in g, the
-non-backtraking matrix B is defined as
+Given two oriented edges `i->j` and `k->l` in `g`, the
+non-backtraking matrix `B` is defined as
 
-B[i->j, k->l] = δ(j,k)* (1 - δ(i,l))
+    B[i->j, k->l] = δ(j,k)* (1 - δ(i,l))
 
 This type is in the style of GraphMatrices.jl and supports the necessary operations
 for computed eigenvectors and conducting linear solves.
 
-Additionally the contract!(vertexspace, nbt, edgespace) method takes vectors represented in
-the domain of B and represents them in the domain of the adjacency matrix of g.
+Additionally the `contraction!(vertexspace, nbt, edgespace)` method takes vectors represented in
+the domain of `B` and represents them in the domain of the adjacency matrix of `g`.
 """
 type Nonbacktracking{G, E}
     g::G
@@ -137,10 +146,12 @@ function *{G, T<:Number}(nbt::Nonbacktracking{G}, x::AbstractMatrix{T})
     return y
 end
 
-"""contract!(vertexspace, nbt, edgespace) in place version of
-contract(nbt, edgespace). modifies first argument
 """
-function contract!{G}(vertexspace::Vector, nbt::Nonbacktracking{G}, edgespace::Vector)
+    contraction!(vertexspace, nbt, edgespace)
+
+In place version of `contraction(nbt, edgespace)`. Modifies the first argument.
+"""
+function contraction!{G}(vertexspace::Vector, nbt::Nonbacktracking{G}, edgespace::Vector)
     E = Edge{vertextype(nbt.g)}
     for i=1:nv(nbt.g)
         for j in neighbors(nbt.g, i)
@@ -150,11 +161,13 @@ function contract!{G}(vertexspace::Vector, nbt::Nonbacktracking{G}, edgespace::V
     end
 end
 
-"""contract(nbt, edgespace)
+"""
+    contraction(nbt, edgespace)
+
 Integrates out the edges by summing over the edges incident to each vertex.
 """
-function contract(nbt::Nonbacktracking, edgespace::Vector)
+function contraction(nbt::Nonbacktracking, edgespace::Vector)
     y = zeros(eltype(edgespace), nv(nbt.g))
-    contract!(y,nbt,edgespace)
+    contraction!(y,nbt,edgespace)
     return y
 end

--- a/src/maps/vertexmap.jl
+++ b/src/maps/vertexmap.jl
@@ -33,11 +33,11 @@ end
 show{G,T,D}(io::IO, m::VertexMap{G,T,D}) = print(io, "VertexMap: $(m.data)")
 
 VertexMap{T}(g::AGraphOrDiGraph, d::AbstractVector{T}) = VertexMap(g, T, d)
-VertexMap{T}(g::AGraphOrDiGraph, d::Dict{Int, T}) = VertexMap(g, T, d)
+VertexMap{V<:Integer,T}(g::AGraphOrDiGraph, d::Dict{V, T}) = VertexMap(g, T, d)
 
 function VertexMap{T}(g::AGraphOrDiGraph, ::Type{T})
     V = vertextype(g)
-    return VertexMap(g, T, Dict{Int,T}())
+    return VertexMap(g, T, Dict{V,T}())
 end
 
 function VertexMap(g::AGraphOrDiGraph, f::Function)

--- a/src/operators/operators.jl
+++ b/src/operators/operators.jl
@@ -1,8 +1,8 @@
 """
     complete(g::ADiGraph)
 
-Returns a digraph containing both the edges `(u,v)`
-of `g` and their reverse `(v,u)`. See also [`complete!`](@ref)
+Returns a digraph containing both the edges `(u, v)`
+of `g` and their reverse `(v, u)`. See also [`complete!`](@ref).
 """
 function complete(g::ADiGraph)
     h = copy(g)
@@ -13,15 +13,12 @@ end
 """
     complete!(g::ADiGraph)
 
-A a digraph containing both the edges `(u,v)`
-of `g` and their reverse `(v,u)`.
+For each edge `(u, v)` in `g`, adds to `g` its reverse, i.e. `(v, u)`.
 """
 function complete!(g::ADiGraph)
     edgs  = collect(edges(g))
     for e in edgs
-        if !has_edge(g, dst(e), src(e))
-            add_edge!(g, dst(e), src(e))
-        end
+        add_edge!(g, dst(e), src(e))
     end
     return g
 end

--- a/src/operators/operators.jl
+++ b/src/operators/operators.jl
@@ -472,3 +472,41 @@ eltype(g::AGraphOrDiGraph) = Float64
 length(g::AGraphOrDiGraph) = nv(g)*nv(g)
 ndims(g::AGraphOrDiGraph) = 2
 issymmetric(g::AGraphOrDiGraph) = !is_directed(g)
+
+"""
+    contract!(g, vs)
+    contract!(g, v1, v2, ....)
+
+Merge the vertices in `vs` into a unique vertex.
+"""
+contract!(g::AGraphOrDiGraph, vs::AbstractVector) = contract!(g, Set(vs))
+contract!(g::AGraphOrDiGraph, vs::Integer...) = contract!(g, Set(vs))
+
+function contract!(g::AGraph, vs::Set)
+    n = add_vertex!(g)
+    for v in vs
+        for u in neighbors(g, v)
+            if u ∉ vs
+                add_edge!(g, n, u)
+            end
+        end
+    end
+    return rem_vertices!(g, vs)
+end
+
+function contract!(g::ADiGraph, vs::Set)
+    n = add_vertex!(g)
+    for v in vs
+        for u in out_neighbors(g, v)
+            if u ∉ vs
+                add_edge!(g, n, u)
+            end
+        end
+        for u in in_neighbors(g, v)
+            if u ∉ vs
+                add_edge!(g, u, n)
+            end
+        end
+    end
+    return rem_vertices!(g, vs)
+end

--- a/src/operators/operators.jl
+++ b/src/operators/operators.jl
@@ -2,7 +2,7 @@
     complete(g::ADiGraph)
 
 Returns a digraph containing both the edges `(u,v)`
-of `g` and their reverse `(v,u)`.
+of `g` and their reverse `(v,u)`. See also [`complete!`](@ref)
 """
 function complete(g::ADiGraph)
     h = copy(g)
@@ -13,7 +13,7 @@ end
 """
     complete!(g::ADiGraph)
 
-Returns a digraph containing both the edges `(u,v)`
+A a digraph containing both the edges `(u,v)`
 of `g` and their reverse `(v,u)`.
 """
 function complete!(g::ADiGraph)
@@ -348,10 +348,6 @@ function _build_subnetwork!(h::ANetOrDiNet, g, vset, newvid)
     end
 end
 
-if VERSION > v"0.6dev"
-    # in julia 0.5 always gets dispatched to this (julia bug)
-    subnetwork(g::AGraphOrDiGraph, list) = subgraph(g, list)
-end
 
 function subnetwork{G<:ANetOrDiNet}(g::G, elist)
     h = G()
@@ -397,6 +393,9 @@ if VERSION >= v"0.6dev"
     for networks.
     """
     getindex(g::AGraphOrDiGraph, iter) = subnetwork(g, iter)[1]
+
+    # in julia 0.5 always gets dispatched to this (julia bug)
+    subnetwork(g::AGraphOrDiGraph, list) = subgraph(g, list)
 else
     """
         g[iter]
@@ -457,13 +456,18 @@ end
 
 
 size(g::AGraphOrDiGraph) = (nv(g), nv(g))
+
 """size(g,i) provides 1:nv or 2:nv else 1 """
 size(g::AGraph,dim::Int) = (dim == 1 || dim == 2)? nv(g) : 1
 
 """sum(g) provides the number of edges in the graph"""
 sum(g::AGraphOrDiGraph) = ne(g)
 
-"""sparse(g) is the adjacency_matrix of g"""
+"""
+    sparse(g)
+
+Equivalent to [`adjacency_matrix`](@ref).
+"""
 sparse(g::AGraphOrDiGraph) = adjacency_matrix(g)
 
 #arrayfunctions = (:eltype, :length, :ndims, :size, :strides, :issymmetric)

--- a/test/centrality/kcore.jl
+++ b/test/centrality/kcore.jl
@@ -19,6 +19,6 @@ klist = cores(g)
 
 h, vmap = kcore(g, 2)
 @test h == CycleGraph(3)
-@test vmap == [1,2,3]
-
+@test length(vmap) == 0
+@test vmap == VertexMap(g, vertextype(g))
 end # testset

--- a/test/core/core.jl
+++ b/test/core/core.jl
@@ -447,6 +447,11 @@ vmap = rem_vertices!(g, 1:5)
 @test length(vmap) == length(unique(vmap)) == 5
 @test sort(vmap) == [6:10;]
 
+g1 = G(10, 30)
+g2 = copy(g1)
+@test rem_vertices!(g1, 1, 2, 2) == rem_vertices!(g2, 1, 2)
+@test g1 == g2
+
 g = G(10,20)
 h = copy(g)
 pop_vertex!(g)

--- a/test/core/core.jl
+++ b/test/core/core.jl
@@ -438,14 +438,41 @@ swap_vertices!(g, 1, 10)
 g = CompleteGraph(10, G)
 vmap = rem_vertices!(g, 6:10)
 @test g == CompleteGraph(5, G)
-@test length(vmap) == length(unique(vmap)) == 5
-@test sort(vmap) == [1:5;]
+@test typeof(vmap) <: AVertexMap
+@test length(vmap) == 0
 
 g = CompleteGraph(10, G)
 vmap = rem_vertices!(g, 1:5)
 @test g == CompleteGraph(5, G)
-@test length(vmap) == length(unique(vmap)) == 5
-@test sort(vmap) == [6:10;]
+@test typeof(vmap) <: AVertexMap
+@test length(vmap) ==  5
+for v=1:5
+    @test vmap[v] == v + 5
+end
+
+g = G(10, 20)
+g2 = copy(g)
+vmap = rem_vertices!(g, 6:10)
+for v=10:-1:6
+    rem_vertex!(g2, v)
+end
+@test g == g2
+@test typeof(vmap) <: AVertexMap
+@test length(vmap) == 0
+
+g = DG(10, 20)
+g2 = copy(g)
+vmap = rem_vertices!(g, 1:5)
+for v=5:-1:1
+    rem_vertex!(g2, v)
+end
+@test g == g2
+@test typeof(vmap) <: AVertexMap
+@test length(vmap) ==  5
+for v=1:5
+    @test vmap[v] == v + 5
+end
+
 
 g1 = G(10, 30)
 g2 = copy(g1)

--- a/test/core/core.jl
+++ b/test/core/core.jl
@@ -475,6 +475,7 @@ g = G(A, upper=true)
 @test !has_edge(g, 1, 3)
 @test !has_edge(g, 2, 2)
 @test has_edge(g, 1, 1)
+@test !has_edge(g, 15, 1)
 g = G(A, upper=true, selfedges=false)
 @test ne(g) == 2
 @test !has_edge(g, 1, 3)
@@ -494,6 +495,8 @@ g = DG(A)
 @test has_edge(g, 1, 1)
 @test !has_edge(g, 2, 2)
 @test has_edge(g, 3, 3)
+@test !has_edge(g, 15, 1)
+
 g = DG(A, selfedges=false)
 @test ne(g) == 5
 @test !has_edge(g, 1, 1)

--- a/test/dismantling/dismantling.jl
+++ b/test/dismantling/dismantling.jl
@@ -5,25 +5,28 @@ h, vmap, reslist = dismantle_ci(g, 2, 1)
 @test reslist == [1]
 @test nv(h) == 9
 @test ne(h) == ne(g) - 9
-@test sort(vmap) == [2:10;]
+@test typeof(vmap) <: AVertexMap
+# @test sort(vmap) == [2:10;]
 
 g = StarGraph(10, G)
 h, vmap, reslist = dismantle_ci(g, 2, 1)
 @test reslist == [1]
 @test nv(h) == 9
 @test ne(h) == 0
-@test sort(vmap) == [2:10;]
+# @test sort(vmap) == [2:10;]
 
 g = PathGraph(3, G)
 h, vmap, reslist = dismantle_ci(g, 2, 1)
 @test reslist == [2]
 @test nv(h) == 2
 @test ne(h) == 0
-@test sort(vmap) == [1,3]
+@test typeof(vmap) <: AVertexMap
+# @test sort(vmap) == [1,3]
 
 g = CompleteGraph(10, G)
 h, vmap, reslist = dismantle_ci(g, 2, 5)
-@test sort([reslist; vmap]) == [1:10;]
+# @test sort([reslist; vmap]) == [1:10;]
 @test h == CompleteGraph(5, G)
+@test typeof(vmap) <: AVertexMap
 
 end # testset

--- a/test/linalg/spectral.jl
+++ b/test/linalg/spectral.jl
@@ -28,9 +28,9 @@ n10 = Nonbacktracking(g10)
 @test eltype(n10) == Float64
 @test !issymmetric(n10)
 
-Erdos.contract!(z, n10, v)
+Erdos.contraction!(z, n10, v)
 
-zprime = contract(n10, v)
+zprime = Erdos.contraction(n10, v)
 @test z == zprime
 @test z == 9*ones(Float64, nv(g10))
 

--- a/test/operators/operators.jl
+++ b/test/operators/operators.jl
@@ -185,6 +185,16 @@ g10 = StarGraph(10, G)
 @test egonet(g10, 1, 0) == G(1, 0)
 @test egonet(g10, 1, 1) == g10
 
+g1 = CompleteGraph(10, G)
+g2 = copy(g1)
+@test contract!(g1, 1, 2, 2) == contract!(g2, 1:2)
+@test g1 == g2 == CompleteGraph(9, G)
+
+g1 = CompleteDiGraph(10, DG)
+g2 = copy(g1)
+@test contract!(g1, 1, 2, 2) == contract!(g2, 1:2)
+@test g1 == g2 == CompleteDiGraph(9, DG)
+
 if G <: ANetwork
     g = readnetwork(:lesmis, G)
 


### PR DESCRIPTION
`contract!` multiple vertices into a single one.

Also,  `rem_vertices!` now returns a vertex map of the reindexed vertices instead of a vector of length `nv(g)`
